### PR TITLE
updated travis CI config to use conda for everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.5"
   - "3.6"
 before_install:
-  - sudo apt-get update
-    #- sudo apt-get install libgdal-dev gdal-bin
+  # - sudo apt-get update
+  #- sudo apt-get install libgdal-dev gdal-bin
   # You may want to periodically update this, although the conda update
   # conda line below will keep everything up-to-date.  We do this
   # conditionally because it saves us some downloading if the version is
@@ -25,15 +25,11 @@ before_install:
   - conda list
   #- sudo rm -rf /dev/shm
   #- sudo ln -s /run/shm /dev/shm
-env:
-  - GDAL_DATA=/usr/share/gdal/2.2/
 install:
-  - conda create -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION pip numpy gdal scipy
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION numpy gdal scipy pytest
   - source activate test-environment
-  - pip install pytest 
-  - "pip install -r requirements.txt"
-  - python setup.py install
-script: 
-  - make test
+  - pip install ./
+script:
+  - pytest tests
 #after_success:
 #  - coveralls #--config_file .coveragerc

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,0 +1,7 @@
+python>=3.6
+numpy
+scipy>=0.17
+gdal
+pytest
+
+


### PR DESCRIPTION
This config uses conda for everything: numpy, scipy, GDAL, etc. More portable to other platforms, and also makes sure to test with conda, so you know you can recommend it to others.

